### PR TITLE
Don't spam the log with result of 'cat' test

### DIFF
--- a/rootfs/etc/services.d/dns-hack/run
+++ b/rootfs/etc/services.d/dns-hack/run
@@ -11,7 +11,7 @@ done
 echo "Starting DNS monitoring loop"
 while true
 do
-    if  ( cat /etc/resolv.conf | grep "nameserver 127.0.0.1" )
+    if  ( cat /etc/resolv.conf | grep "nameserver 127.0.0.1" >/dev/null )
     then
         sleep 30
         continue


### PR DESCRIPTION
 "docker logs" is spammed with a lot of lines like this:
nameserver 127.0.0.1
nameserver 127.0.0.1
nameserver 127.0.0.1
nameserver 127.0.0.1

patch should fix this.
